### PR TITLE
Implement LLM-driven Bithumb trading engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-None
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
-# StrategyStandardization
-표준화 선도 전략
+# LLM 기반 자동화 코인 트레이드 시스템 (Bithumb)
+
+이 프로젝트는 Bithumb 거래소를 대상으로 한 **LLM 기반 의사결정 자동매매 엔진**을 제공합니다. 
+공개 시세/호가 데이터와 계좌 정보를 수집하고, 언어모델이 생성한 트레이딩 결정을 리스크 매니저가 검증하여 
+주문 집행(또는 드라이런)까지 자동으로 수행할 수 있는 구조를 갖추고 있습니다.
+
+## 주요 구성 요소
+
+| 모듈 | 역할 |
+| --- | --- |
+| `bithumb_llm_trader.api_client` | Bithumb 공개/개인 REST API 래퍼 및 시그니처 생성 |
+| `bithumb_llm_trader.config` | 전략/위험/LLM 설정 로더 및 데이터 클래스 |
+| `bithumb_llm_trader.prompts` | 시장/계좌 정보를 기반으로 프롬프트 생성 |
+| `bithumb_llm_trader.decision` | LLM 출력 JSON 파싱 및 검증 로직 |
+| `bithumb_llm_trader.risk` | 리스크 한도(신뢰도·포지션·손절/익절) 적용 |
+| `bithumb_llm_trader.engine` | 전체 파이프라인(데이터 수집 → LLM 의사결정 → 리스크 검증 → 주문) 조율 |
+| `bithumb_llm_trader.main` | CLI 실행 진입점 (`python -m bithumb_llm_trader.main`) |
+
+모듈은 모두 독립적으로 테스트 가능하도록 설계되었으며, `tests/` 디렉터리의 Pytest 스위트가 핵심 동작을 검증합니다.
+
+## 설정 파일 작성
+
+전략 설정은 JSON/YAML/TOML 파일로 정의할 수 있습니다. 예시(`config.sample.json`):
+
+```json
+{
+  "api": {
+    "api_key": "YOUR_BITHUMB_API_KEY",
+    "api_secret": "YOUR_BITHUMB_API_SECRET",
+    "base_url": "https://api.bithumb.com",
+    "timeout": 10.0
+  },
+  "trading_pair": {
+    "order_currency": "BTC",
+    "payment_currency": "KRW"
+  },
+  "risk": {
+    "max_trade_value": 1000000,
+    "max_position_size": 0.2,
+    "stop_loss_pct": 0.02,
+    "take_profit_pct": 0.03,
+    "min_confidence": 0.6
+  },
+  "llm": {
+    "model": "gpt-4o-mini",
+    "temperature": 0.0,
+    "max_output_tokens": 512
+  },
+  "dry_run": true
+}
+```
+
+* `dry_run` 값을 `true`로 두면 주문을 실행하지 않고 시뮬레이션만 수행합니다.
+* YAML(`.yml`, `.yaml`) 또는 TOML(`.toml`) 포맷도 동일한 필드 구조를 따릅니다.
+
+## 실행 방법
+
+1. (선택) OpenAI API 키를 환경 변수에 설정합니다.
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   ```
+2. 설정 파일을 준비합니다. (위 JSON 예시 활용)
+3. 아래 명령으로 단일 사이클을 실행할 수 있습니다.
+   ```bash
+   python -m bithumb_llm_trader.main path/to/config.json --verbose
+   ```
+   * `--openai-api-key` 옵션으로 환경 변수 대신 키를 직접 전달할 수 있습니다.
+   * 실행 결과는 JSON 형식으로 표준 출력에 표시되며, `dry_run`이 `false`이면 실제 주문이 전송됩니다.
+
+## 동작 흐름
+
+1. **데이터 수집** – `BithumbAPI`가 시세/호가/잔고를 조회합니다.
+2. **프롬프트 생성** – `build_trading_prompt`가 시장·계좌·리스크 정보를 정리합니다.
+3. **LLM 의사결정** – `LLMDecisionMaker`가 언어모델 응답을 받아 `TradeDecision`으로 파싱합니다.
+4. **리스크 필터링** – `RiskManager`가 신뢰도·자금·포지션 한도를 점검하고 손절/익절 가격을 부여합니다.
+5. **주문 실행** – 드라이런 여부에 따라 실제 주문을 전송하거나, 실행 정보만 기록합니다.
+6. **이력 관리** – 최근 의사결정/실행 내역은 `TradingEngine.history`에 보관됩니다.
+
+## 테스트
+
+Pytest 스위트가 주요 로직(시그니처 생성, 의사결정 파서, 리스크 매니저, 엔진 플로우)을 검증합니다.
+
+```bash
+pytest
+```
+
+## 주의 사항
+
+- 실제 운용 시 **API 키 보안**과 **LLM 응답 검증**을 반드시 강화해야 합니다.
+- 언어모델 호출에는 비용이 발생하며, 응답 지연을 고려한 추가 설계(비동기, 큐 관리 등)가 필요할 수 있습니다.
+- 본 예제 코드는 참고용으로 제공되며, 실거래 전 충분한 시뮬레이션과 검증이 선행되어야 합니다.

--- a/bithumb_llm_trader/__init__.py
+++ b/bithumb_llm_trader/__init__.py
@@ -1,0 +1,25 @@
+"""High-level package for an LLM-driven automated trading system targeting Bithumb."""
+
+from .config import APIConfig, LLMConfig, RiskConfig, StrategyConfig, TradingPairConfig
+from .api_client import BithumbAPI, BithumbAPIError
+from .decision import Action, TradeDecision
+from .engine import TradingEngine
+from .llm import LLMDecisionMaker, LLMClient, OpenAIChatClient
+from .risk import RiskManager
+
+__all__ = [
+    "APIConfig",
+    "LLMConfig",
+    "RiskConfig",
+    "StrategyConfig",
+    "TradingPairConfig",
+    "BithumbAPI",
+    "BithumbAPIError",
+    "Action",
+    "TradeDecision",
+    "TradingEngine",
+    "LLMDecisionMaker",
+    "LLMClient",
+    "OpenAIChatClient",
+    "RiskManager",
+]

--- a/bithumb_llm_trader/api_client.py
+++ b/bithumb_llm_trader/api_client.py
@@ -1,0 +1,184 @@
+"""HTTP client for interacting with the Bithumb REST API."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol, Tuple
+
+
+class BithumbAPIError(RuntimeError):
+    """Exception raised when the Bithumb API reports an error."""
+
+    def __init__(self, message: str, payload: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.payload = payload or {}
+
+
+class Transport(Protocol):
+    """Protocol for pluggable HTTP transports."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: Dict[str, str],
+        data: Optional[bytes],
+        timeout: float,
+    ) -> Tuple[int, bytes]:
+        """Perform an HTTP request and return a status code with a body."""
+
+
+class UrllibTransport:
+    """Default transport implementation built on top of :mod:`urllib`."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: Dict[str, str],
+        data: Optional[bytes],
+        timeout: float,
+    ) -> Tuple[int, bytes]:
+        request = urllib.request.Request(url=url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return response.getcode(), response.read()
+        except urllib.error.HTTPError as exc:  # pragma: no cover - network failure path
+            return exc.code, exc.read()
+
+
+@dataclass(slots=True)
+class BithumbAPI:
+    """Thin wrapper around Bithumb's REST endpoints."""
+
+    api_key: str
+    api_secret: str
+    base_url: str = "https://api.bithumb.com"
+    timeout: float = 10.0
+    transport: Transport = UrllibTransport()
+
+    def _nonce(self) -> str:
+        return str(int(time.time() * 1000))
+
+    def _sign(self, endpoint: str, body: str, nonce: str) -> str:
+        message = endpoint.encode() + b"\0" + body.encode() + b"\0" + nonce.encode()
+        signature = hmac.new(self.api_secret.encode(), message, hashlib.sha512).digest()
+        return base64.b64encode(signature).decode()
+
+    def _public_request(
+        self, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        url = urllib.parse.urljoin(self.base_url, endpoint)
+        if params:
+            query = urllib.parse.urlencode(params)
+            url = f"{url}?{query}"
+        status, body = self.transport.request("GET", url, {}, None, self.timeout)
+        return self._parse_response(status, body)
+
+    def _private_request(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        params = params or {}
+        body = urllib.parse.urlencode(params)
+        nonce = self._nonce()
+        signature = self._sign(endpoint, body, nonce)
+        headers = {
+            "Api-Key": self.api_key,
+            "Api-Sign": signature,
+            "Api-Nonce": nonce,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        url = urllib.parse.urljoin(self.base_url, endpoint)
+        status, response = self.transport.request(
+            "POST", url, headers, body.encode(), self.timeout
+        )
+        return self._parse_response(status, response)
+
+    def _parse_response(self, status: int, body: bytes) -> Dict[str, Any]:
+        if status >= 400:
+            raise BithumbAPIError(f"HTTP error from Bithumb: {status}")
+        text = body.decode() if body else "{}"
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+            raise BithumbAPIError("Invalid JSON response", {"body": text}) from exc
+        status_code = payload.get("status")
+        if status_code not in (None, "0000"):
+            raise BithumbAPIError(payload.get("message", "Unknown error"), payload)
+        return payload
+
+    # ------------------------------------------------------------------
+    # Public endpoints
+    # ------------------------------------------------------------------
+    def get_ticker(self, order_currency: str, payment_currency: str) -> Dict[str, Any]:
+        endpoint = f"/public/ticker/{order_currency}_{payment_currency}"
+        return self._public_request(endpoint)
+
+    def get_orderbook(self, order_currency: str, payment_currency: str) -> Dict[str, Any]:
+        endpoint = f"/public/orderbook/{order_currency}_{payment_currency}"
+        return self._public_request(endpoint)
+
+    def get_recent_transactions(
+        self, order_currency: str, payment_currency: str
+    ) -> Dict[str, Any]:
+        endpoint = f"/public/recent_transactions/{order_currency}_{payment_currency}"
+        return self._public_request(endpoint)
+
+    # ------------------------------------------------------------------
+    # Private endpoints
+    # ------------------------------------------------------------------
+    def get_balance(self, order_currency: str, payment_currency: str) -> Dict[str, Any]:
+        params = {
+            "currency": order_currency,
+            "payment_currency": payment_currency,
+        }
+        return self._private_request("/info/balance", params)
+
+    def place_order(
+        self,
+        order_type: str,
+        order_currency: str,
+        payment_currency: str,
+        units: str,
+        price: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "order_currency": order_currency,
+            "payment_currency": payment_currency,
+            "units": units,
+            "type": order_type,
+        }
+        if price is not None:
+            params["price"] = price
+        return self._private_request("/trade/place", params)
+
+    def cancel_order(
+        self,
+        order_id: str,
+        order_currency: str,
+        payment_currency: str,
+        order_type: str,
+    ) -> Dict[str, Any]:
+        params = {
+            "type": order_type,
+            "order_id": order_id,
+            "order_currency": order_currency,
+            "payment_currency": payment_currency,
+        }
+        return self._private_request("/trade/cancel", params)
+
+    def get_open_orders(self, order_currency: str, payment_currency: str) -> Dict[str, Any]:
+        params = {
+            "order_currency": order_currency,
+            "payment_currency": payment_currency,
+        }
+        return self._private_request("/info/orders", params)
+
+
+__all__ = ["BithumbAPI", "BithumbAPIError", "Transport", "UrllibTransport"]

--- a/bithumb_llm_trader/config.py
+++ b/bithumb_llm_trader/config.py
@@ -1,0 +1,129 @@
+"""Configuration helpers for the LLM-driven Bithumb trading system."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
+    tomllib = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class APIConfig:
+    """Holds credentials and networking parameters for the Bithumb API."""
+
+    api_key: str
+    api_secret: str
+    base_url: str = "https://api.bithumb.com"
+    timeout: float = 10.0
+
+
+@dataclass(slots=True)
+class TradingPairConfig:
+    """Represents the trading pair configuration for the strategy."""
+
+    order_currency: str = "BTC"
+    payment_currency: str = "KRW"
+
+
+@dataclass(slots=True)
+class RiskConfig:
+    """Parameters that constrain order sizing and manage downside risk."""
+
+    max_trade_value: float = 1_000_000.0  # in payment currency (KRW)
+    max_position_size: float = 0.2  # maximum units of the asset to trade in one order
+    stop_loss_pct: float = 0.02  # 2% below the entry price
+    take_profit_pct: float = 0.03  # 3% above the entry price
+    min_confidence: float = 0.55  # minimum LLM confidence required to trade
+
+
+@dataclass(slots=True)
+class LLMConfig:
+    """Configuration for the language model that generates trade decisions."""
+
+    model: str = "gpt-4o-mini"
+    temperature: float = 0.0
+    max_output_tokens: int = 512
+
+
+@dataclass(slots=True)
+class StrategyConfig:
+    """Top-level configuration object consumed by the trading engine."""
+
+    api: APIConfig
+    trading_pair: TradingPairConfig = field(default_factory=TradingPairConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)
+    llm: LLMConfig = field(default_factory=LLMConfig)
+    dry_run: bool = True
+    prompt_template: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "StrategyConfig":
+        """Construct :class:`StrategyConfig` from a plain dictionary."""
+
+        api_cfg = APIConfig(**data["api"])
+        trading_cfg = TradingPairConfig(**data.get("trading_pair", {}))
+        risk_cfg = RiskConfig(**data.get("risk", {}))
+        llm_cfg = LLMConfig(**data.get("llm", {}))
+        dry_run = data.get("dry_run", True)
+        prompt_template = data.get("prompt_template")
+        return cls(
+            api=api_cfg,
+            trading_pair=trading_cfg,
+            risk=risk_cfg,
+            llm=llm_cfg,
+            dry_run=dry_run,
+            prompt_template=prompt_template,
+        )
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "PyYAML is required to load YAML configuration files. Install it via 'pip install pyyaml'."
+        ) from exc
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _load_toml(path: Path) -> Dict[str, Any]:
+    if tomllib is None:  # pragma: no cover - Python < 3.11 fallback
+        raise RuntimeError("TOML configuration files require Python 3.11 or newer.")
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def load_config(path: Union[str, os.PathLike[str]]) -> StrategyConfig:
+    """Load configuration data from JSON, YAML, or TOML files."""
+
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {file_path}")
+
+    suffix = file_path.suffix.lower()
+    if suffix == ".json":
+        data = _load_json(file_path)
+    elif suffix in {".yml", ".yaml"}:
+        data = _load_yaml(file_path)
+    elif suffix == ".toml":
+        data = _load_toml(file_path)
+    else:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unsupported configuration format: {suffix}")
+
+    if not isinstance(data, dict):
+        raise ValueError("Configuration file must contain a dictionary at the top level.")
+
+    return StrategyConfig.from_dict(data)

--- a/bithumb_llm_trader/decision.py
+++ b/bithumb_llm_trader/decision.py
@@ -1,0 +1,130 @@
+"""Utilities for interpreting and validating LLM trade decisions."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class DecisionParseError(ValueError):
+    """Raised when the LLM output cannot be converted into a decision."""
+
+
+class Action(str, Enum):
+    """Enumeration of supported trade actions."""
+
+    BUY = "BUY"
+    SELL = "SELL"
+    HOLD = "HOLD"
+
+    @classmethod
+    def from_text(cls, value: str) -> "Action":
+        upper = value.strip().upper()
+        try:
+            return cls[upper]
+        except KeyError as exc:
+            raise DecisionParseError(f"Unsupported action: {value}") from exc
+
+
+@dataclass(slots=True)
+class TradeDecision:
+    """Structured representation of a trading decision."""
+
+    action: Action
+    confidence: float
+    amount: float
+    target_price: Optional[float] = None
+    reasoning: str = ""
+    stop_loss: Optional[float] = None
+    take_profit: Optional[float] = None
+    raw_response: Optional[str] = None
+
+    def validate(self) -> "TradeDecision":
+        if not 0 <= self.confidence <= 1:
+            raise DecisionParseError("Confidence must be between 0 and 1")
+        if self.amount < 0:
+            raise DecisionParseError("Trade amount cannot be negative")
+        if self.target_price is not None and self.target_price <= 0:
+            raise DecisionParseError("Target price must be positive when provided")
+        return self
+
+    def with_adjustments(
+        self,
+        *,
+        amount: Optional[float] = None,
+        target_price: Optional[float] = None,
+        reasoning: Optional[str] = None,
+        stop_loss: Optional[float] = None,
+        take_profit: Optional[float] = None,
+    ) -> "TradeDecision":
+        return replace(
+            self,
+            amount=self.amount if amount is None else amount,
+            target_price=self.target_price if target_price is None else target_price,
+            reasoning=self.reasoning if reasoning is None else reasoning,
+            stop_loss=self.stop_loss if stop_loss is None else stop_loss,
+            take_profit=self.take_profit if take_profit is None else take_profit,
+        )
+
+    @classmethod
+    def hold(cls, confidence: float, reasoning: str, raw_response: Optional[str] = None) -> "TradeDecision":
+        return cls(
+            action=Action.HOLD,
+            confidence=confidence,
+            amount=0.0,
+            reasoning=reasoning,
+            raw_response=raw_response,
+        )
+
+
+class DecisionParser:
+    """Parses the raw text output of an LLM into :class:`TradeDecision`."""
+
+    JSON_PATTERN = re.compile(r"\{.*\}", re.DOTALL)
+
+    def parse(self, text: str) -> TradeDecision:
+        candidate = self._extract_json_block(text)
+        try:
+            data = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            raise DecisionParseError("LLM response did not contain valid JSON") from exc
+        return self._decision_from_dict(data, text)
+
+    def _extract_json_block(self, text: str) -> str:
+        # Support Markdown code fences surrounding the JSON payload
+        fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+        if fenced:
+            return fenced.group(1)
+        match = self.JSON_PATTERN.search(text)
+        if not match:
+            raise DecisionParseError("Could not locate a JSON object in LLM response")
+        return match.group(0)
+
+    def _decision_from_dict(self, data: Dict[str, Any], raw: str) -> TradeDecision:
+        if "action" not in data:
+            raise DecisionParseError("Decision JSON must include an 'action' field")
+        action = Action.from_text(str(data["action"]))
+        confidence = float(data.get("confidence", 0))
+        amount = float(data.get("amount", 0))
+        target_price = data.get("target_price")
+        target_value = float(target_price) if target_price is not None else None
+        reasoning = str(data.get("reasoning", "")).strip()
+        stop_loss = data.get("stop_loss")
+        take_profit = data.get("take_profit")
+        decision = TradeDecision(
+            action=action,
+            confidence=confidence,
+            amount=amount,
+            target_price=target_value,
+            reasoning=reasoning,
+            stop_loss=float(stop_loss) if stop_loss is not None else None,
+            take_profit=float(take_profit) if take_profit is not None else None,
+            raw_response=raw,
+        )
+        return decision.validate()
+
+
+__all__ = ["Action", "DecisionParseError", "DecisionParser", "TradeDecision"]

--- a/bithumb_llm_trader/engine.py
+++ b/bithumb_llm_trader/engine.py
@@ -1,0 +1,154 @@
+"""Trading engine orchestrating API calls, LLM inference and risk controls."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from .api_client import BithumbAPI, BithumbAPIError
+from .config import StrategyConfig
+from .decision import Action, TradeDecision
+from .llm import LLMDecisionMaker
+from .risk import RiskManager
+
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _format_units(value: float) -> str:
+    formatted = f"{value:.8f}".rstrip("0").rstrip(".")
+    return formatted or "0"
+
+
+@dataclass(slots=True)
+class TradingEngine:
+    """Coordinates the different components of the automated trading stack."""
+
+    api: BithumbAPI
+    decision_maker: LLMDecisionMaker
+    config: StrategyConfig
+    risk_manager: RiskManager = field(init=False)
+    history: List[Dict[str, Any]] = field(default_factory=list, init=False)
+    max_history: int = 50
+
+    def __post_init__(self) -> None:
+        self.risk_manager = RiskManager(self.config.risk)
+
+    # ------------------------------------------------------------------
+    def fetch_market_state(self) -> Dict[str, Any]:
+        pair = self.config.trading_pair
+        ticker = self.api.get_ticker(pair.order_currency, pair.payment_currency)
+        orderbook = self.api.get_orderbook(pair.order_currency, pair.payment_currency)
+        return {
+            "ticker": ticker.get("data", ticker),
+            "orderbook": orderbook.get("data", orderbook),
+        }
+
+    def fetch_account_state(self) -> Dict[str, Any]:
+        pair = self.config.trading_pair
+        response = self.api.get_balance(pair.order_currency, pair.payment_currency)
+        data = response.get("data", response)
+        balance_order = self._extract_balance(data, pair.order_currency)
+        balance_payment = self._extract_balance(data, pair.payment_currency)
+        return {
+            "balance_order_currency": balance_order,
+            "balance_payment_currency": balance_payment,
+            "raw": data,
+        }
+
+    def run_once(self) -> TradeDecision:
+        market_state = self.fetch_market_state()
+        account_state = self.fetch_account_state()
+        decision = self.decision_maker.decide(
+            market_state, account_state, self.config, self.history
+        )
+        adjusted = self.risk_manager.apply(decision, market_state, account_state)
+        executed = self._execute(adjusted, market_state, account_state)
+        self._record_history(executed)
+        return executed
+
+    # ------------------------------------------------------------------
+    def _execute(
+        self,
+        decision: TradeDecision,
+        market_state: Dict[str, Any],
+        account_state: Dict[str, Any],
+    ) -> TradeDecision:
+        if decision.action is Action.HOLD or decision.amount <= 0:
+            logger.info("No trade executed: %s", decision.reasoning)
+            return decision
+
+        price = decision.target_price or _safe_float(market_state["ticker"].get("closing_price"))
+        if price <= 0:
+            logger.warning("Execution aborted: invalid price derived from market data.")
+            return TradeDecision.hold(
+                confidence=decision.confidence,
+                reasoning="Execution aborted due to invalid price.",
+                raw_response=decision.raw_response,
+            )
+
+        if self.config.dry_run:
+            logger.info(
+                "Dry-run mode: %s %s units at %s", decision.action.value, decision.amount, price
+            )
+            return decision.with_adjustments(target_price=price)
+
+        order_type = "bid" if decision.action is Action.BUY else "ask"
+        units = _format_units(decision.amount)
+        pair = self.config.trading_pair
+        try:
+            response = self.api.place_order(
+                order_type=order_type,
+                order_currency=pair.order_currency,
+                payment_currency=pair.payment_currency,
+                units=units,
+                price=_format_units(price),
+            )
+            logger.info("Order response: %s", response)
+        except BithumbAPIError as exc:
+            logger.error("Order placement failed: %s", exc)
+            return TradeDecision.hold(
+                confidence=decision.confidence,
+                reasoning=f"Order rejected by exchange: {exc}",
+                raw_response=decision.raw_response,
+            )
+        return decision.with_adjustments(target_price=price)
+
+    def _extract_balance(self, data: Dict[str, Any], currency: str) -> float:
+        keys = [
+            f"available_{currency.lower()}",
+            f"available_{currency.upper()}",
+            f"available_{currency}",
+            currency.lower(),
+            currency.upper(),
+            currency,
+        ]
+        for key in keys:
+            if key in data:
+                return _safe_float(data[key])
+        return 0.0
+
+    def _record_history(self, decision: TradeDecision) -> None:
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "action": decision.action.value,
+            "amount": decision.amount,
+            "price": decision.target_price,
+            "confidence": decision.confidence,
+            "reasoning": decision.reasoning,
+        }
+        self.history.append(entry)
+        if len(self.history) > self.max_history:
+            self.history = self.history[-self.max_history :]
+
+
+__all__ = ["TradingEngine"]

--- a/bithumb_llm_trader/llm.py
+++ b/bithumb_llm_trader/llm.py
@@ -1,0 +1,80 @@
+"""LLM client abstractions used by the trading engine."""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, Optional
+
+from .config import LLMConfig, StrategyConfig
+from .decision import DecisionParser, TradeDecision
+from .prompts import build_trading_prompt
+
+
+class LLMClient(ABC):
+    """Abstract base class describing a minimal language model client."""
+
+    @abstractmethod
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Generate a textual completion for ``prompt``."""
+
+
+class OpenAIChatClient(LLMClient):
+    """Adapter around the ``openai`` Python package (Responses API)."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OpenAI API key must be provided via argument or OPENAI_API_KEY env variable")
+        try:
+            from openai import OpenAI
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "The 'openai' package is required for OpenAIChatClient. Install it via 'pip install openai'."
+            ) from exc
+        self._client = OpenAI(api_key=self.api_key)
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        model = kwargs.get("model", "gpt-4o-mini")
+        temperature = kwargs.get("temperature", 0.0)
+        max_tokens = kwargs.get("max_output_tokens", 512)
+        response = self._client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+            max_output_tokens=max_tokens,
+        )
+        return response.output_text  # type: ignore[return-value]
+
+
+class LLMDecisionMaker:
+    """High-level helper that turns market context into a :class:`TradeDecision`."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        parser: Optional[DecisionParser] = None,
+        llm_config: Optional[LLMConfig] = None,
+    ) -> None:
+        self.client = client
+        self.parser = parser or DecisionParser()
+        self.llm_config = llm_config or LLMConfig()
+
+    def decide(
+        self,
+        market_data: Dict[str, Any],
+        account_state: Dict[str, Any],
+        config: StrategyConfig,
+        history: Optional[Iterable[Dict[str, Any]]] = None,
+    ) -> TradeDecision:
+        prompt = build_trading_prompt(market_data, account_state, config, history)
+        response = self.client.generate(
+            prompt,
+            model=self.llm_config.model,
+            temperature=self.llm_config.temperature,
+            max_output_tokens=self.llm_config.max_output_tokens,
+        )
+        return self.parser.parse(response)
+
+
+__all__ = ["LLMClient", "LLMDecisionMaker", "OpenAIChatClient"]

--- a/bithumb_llm_trader/main.py
+++ b/bithumb_llm_trader/main.py
@@ -1,0 +1,63 @@
+"""Command line entry point for running the trading engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .api_client import BithumbAPI
+from .config import StrategyConfig, load_config
+from .engine import TradingEngine
+from .llm import LLMDecisionMaker, OpenAIChatClient
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def summarize_decision(decision: Any) -> str:
+    return json.dumps(
+        {
+            "action": decision.action.value,
+            "amount": decision.amount,
+            "price": decision.target_price,
+            "confidence": decision.confidence,
+            "reasoning": decision.reasoning,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def run_once(config: StrategyConfig, openai_api_key: str | None) -> None:
+    api = BithumbAPI(
+        api_key=config.api.api_key,
+        api_secret=config.api.api_secret,
+        base_url=config.api.base_url,
+        timeout=config.api.timeout,
+    )
+    llm_client = OpenAIChatClient(api_key=openai_api_key)
+    decision_maker = LLMDecisionMaker(llm_client, llm_config=config.llm)
+    engine = TradingEngine(api, decision_maker, config)
+    decision = engine.run_once()
+    print(summarize_decision(decision))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="LLM-driven automated trader for Bithumb")
+    parser.add_argument("config", type=Path, help="Path to strategy configuration file")
+    parser.add_argument("--openai-api-key", dest="openai_api_key", help="Override OpenAI API key")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    configure_logging(args.verbose)
+    config = load_config(args.config)
+    run_once(config, args.openai_api_key)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/bithumb_llm_trader/prompts.py
+++ b/bithumb_llm_trader/prompts.py
@@ -1,0 +1,91 @@
+"""Prompt templates used to instruct the LLM."""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any, Dict, Iterable, Optional
+
+from .config import StrategyConfig
+
+
+def _format_orderbook(orderbook: Dict[str, Any], depth: int = 5) -> str:
+    bids = orderbook.get("bids") or orderbook.get("bid") or []
+    asks = orderbook.get("asks") or orderbook.get("ask") or []
+    bid_lines = [f"{idx+1}. {b['price']} ({b.get('quantity') or b.get('amount')})" for idx, b in enumerate(bids[:depth])]
+    ask_lines = [f"{idx+1}. {a['price']} ({a.get('quantity') or a.get('amount')})" for idx, a in enumerate(asks[:depth])]
+    return "\n".join(
+        ["Top Asks:"] + ask_lines + ["", "Top Bids:"] + bid_lines
+    )
+
+
+def build_trading_prompt(
+    market_data: Dict[str, Any],
+    account_state: Dict[str, Any],
+    config: StrategyConfig,
+    history: Optional[Iterable[Dict[str, Any]]] = None,
+) -> str:
+    ticker = market_data.get("ticker", {})
+    orderbook = market_data.get("orderbook", {})
+    last_actions = list(history or [])[-3:]
+    history_block = "\n".join(
+        f"- {item['timestamp']}: {item['action']} ({item['details']})" for item in last_actions
+    ) or "- No previous trades"
+    template = config.prompt_template or textwrap.dedent(
+        """
+        You are an autonomous crypto trading strategist operating on the Bithumb exchange.
+        Analyse the provided market data and account balances to decide whether to BUY, SELL or HOLD
+        the pair {order_currency}/{payment_currency}. Your answer must be a single JSON object with the following fields:
+        - action: one of BUY, SELL, HOLD
+        - confidence: value between 0 and 1
+        - amount: number of {order_currency} units to trade
+        - target_price: desired execution price in {payment_currency} (optional)
+        - reasoning: concise explanation for the decision
+        - stop_loss: optional stop loss price in {payment_currency}
+        - take_profit: optional take profit price in {payment_currency}
+
+        Ensure the JSON is valid and does not include additional commentary.
+        """
+    ).strip()
+
+    order_currency = config.trading_pair.order_currency
+    payment_currency = config.trading_pair.payment_currency
+    prompt = template.format(order_currency=order_currency, payment_currency=payment_currency)
+
+    price_info = textwrap.dedent(
+        f"""
+        Market snapshot:
+        - Closing price: {ticker.get('closing_price')}
+        - 24h change (%): {ticker.get('fluctate_rate_24H')}
+        - 24h volume: {ticker.get('acc_trade_value_24H')}
+
+        Orderbook (top levels):
+        {_format_orderbook(orderbook)}
+        """
+    ).strip()
+
+    balance_info = textwrap.dedent(
+        f"""
+        Account:
+        - Available {order_currency}: {account_state.get('balance_order_currency')}
+        - Available {payment_currency}: {account_state.get('balance_payment_currency')}
+        - Position value limit: {config.risk.max_trade_value} {payment_currency}
+        - Position size limit: {config.risk.max_position_size} {order_currency}
+        """
+    ).strip()
+
+    risk_info = textwrap.dedent(
+        f"""
+        Risk constraints:
+        - Minimum confidence to trade: {config.risk.min_confidence}
+        - Stop loss tolerance: {config.risk.stop_loss_pct*100:.2f}%
+        - Take profit target: {config.risk.take_profit_pct*100:.2f}%
+        Trade history:
+        {history_block}
+        """
+    ).strip()
+
+    sections = [prompt, price_info, balance_info, risk_info]
+    return "\n\n".join(sections)
+
+
+__all__ = ["build_trading_prompt"]

--- a/bithumb_llm_trader/risk.py
+++ b/bithumb_llm_trader/risk.py
@@ -1,0 +1,130 @@
+"""Risk management utilities for the trading engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from .config import RiskConfig
+from .decision import Action, TradeDecision
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(slots=True)
+class RiskManager:
+    """Applies sizing and confidence constraints to trade decisions."""
+
+    config: RiskConfig
+
+    def apply(
+        self,
+        decision: TradeDecision,
+        market_data: Dict[str, Any],
+        account_state: Dict[str, Any],
+    ) -> TradeDecision:
+        if decision.action is Action.HOLD:
+            return decision
+        if decision.confidence < self.config.min_confidence:
+            return TradeDecision.hold(
+                confidence=decision.confidence,
+                reasoning=(
+                    f"Decision rejected by risk manager: confidence {decision.confidence:.2f} "
+                    f"below threshold {self.config.min_confidence:.2f}."
+                ),
+                raw_response=decision.raw_response,
+            )
+
+        price = self._resolve_price(decision, market_data)
+        if price <= 0:
+            return TradeDecision.hold(
+                confidence=decision.confidence,
+                reasoning="Decision rejected: unable to determine valid execution price.",
+                raw_response=decision.raw_response,
+            )
+
+        if decision.action is Action.BUY:
+            return self._assess_buy(decision, price, account_state)
+        if decision.action is Action.SELL:
+            return self._assess_sell(decision, price, account_state)
+        return decision
+
+    # ------------------------------------------------------------------
+    def _assess_buy(
+        self, decision: TradeDecision, price: float, account_state: Dict[str, Any]
+    ) -> TradeDecision:
+        available_cash = _safe_float(account_state.get("balance_payment_currency"))
+        max_by_cash = available_cash / price if price else 0.0
+        max_by_value = self.config.max_trade_value / price if price else 0.0
+        allowed = min(
+            max(decision.amount, 0.0),
+            self.config.max_position_size,
+            max_by_cash,
+            max_by_value,
+        )
+        if allowed <= 0:
+            return TradeDecision.hold(
+                confidence=decision.confidence,
+                reasoning="Insufficient funds to execute BUY order.",
+                raw_response=decision.raw_response,
+            )
+        adjusted = decision.with_adjustments(amount=allowed)
+        return self._attach_protection_levels(adjusted, price)
+
+    def _assess_sell(
+        self, decision: TradeDecision, price: float, account_state: Dict[str, Any]
+    ) -> TradeDecision:
+        available_asset = _safe_float(account_state.get("balance_order_currency"))
+        allowed = min(
+            max(decision.amount, 0.0),
+            self.config.max_position_size,
+            available_asset,
+        )
+        if allowed <= 0:
+            return TradeDecision.hold(
+                confidence=decision.confidence,
+                reasoning="No inventory available to SELL.",
+                raw_response=decision.raw_response,
+            )
+        adjusted = decision.with_adjustments(amount=allowed)
+        return self._attach_protection_levels(adjusted, price)
+
+    def _resolve_price(self, decision: TradeDecision, market_data: Dict[str, Any]) -> float:
+        if decision.target_price:
+            return decision.target_price
+        ticker = market_data.get("ticker", {})
+        candidates = [
+            ticker.get("closing_price"),
+            ticker.get("closePrice"),
+            ticker.get("price"),
+        ]
+        for value in candidates:
+            price = _safe_float(value, -1)
+            if price > 0:
+                return price
+        return -1.0
+
+    def _attach_protection_levels(self, decision: TradeDecision, entry_price: float) -> TradeDecision:
+        if entry_price <= 0:
+            return decision
+        if decision.action is Action.BUY:
+            stop_loss = entry_price * (1 - self.config.stop_loss_pct)
+            take_profit = entry_price * (1 + self.config.take_profit_pct)
+        else:
+            stop_loss = entry_price * (1 + self.config.stop_loss_pct)
+            take_profit = entry_price * (1 - self.config.take_profit_pct)
+        reasoning = decision.reasoning or ""
+        reasoning = reasoning + " | Risk controls applied"
+        return decision.with_adjustments(
+            stop_loss=stop_loss,
+            take_profit=take_profit,
+            reasoning=reasoning.strip(),
+        )
+
+
+__all__ = ["RiskManager"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "bithumb-llm-trader"
+version = "0.1.0"
+description = "LLM 기반 Bithumb 자동매매 엔진"
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,47 @@
+"""Tests for the low level Bithumb API client."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+
+from bithumb_llm_trader.api_client import BithumbAPI
+
+
+class RecordingTransport:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.calls = []
+
+    def request(self, method, url, headers, data, timeout):  # type: ignore[override]
+        self.calls.append({
+            "method": method,
+            "url": url,
+            "headers": headers,
+            "data": data,
+            "timeout": timeout,
+        })
+        return 200, json.dumps(self.payload).encode()
+
+
+def test_signature_matches_reference():
+    api = BithumbAPI(api_key="key", api_secret="secret")
+    signature = api._sign("/info/balance", "currency=BTC", "1234")
+    expected = base64.b64encode(
+        hmac.new(b"secret", b"/info/balance\x00currency=BTC\x001234", hashlib.sha512).digest()
+    ).decode()
+    assert signature == expected
+
+
+def test_private_request_sends_auth_headers():
+    transport = RecordingTransport({"status": "0000", "data": {"available_btc": "1"}})
+    api = BithumbAPI(api_key="key", api_secret="secret", transport=transport)
+
+    response = api.get_balance("BTC", "KRW")
+
+    call = transport.calls[0]
+    assert call["headers"]["Api-Key"] == "key"
+    assert "Api-Sign" in call["headers"]
+    assert response["data"]["available_btc"] == "1"

--- a/tests/test_decision_parser.py
+++ b/tests/test_decision_parser.py
@@ -1,0 +1,45 @@
+"""Tests for parsing LLM generated trade decisions."""
+
+from __future__ import annotations
+
+import pytest
+
+from bithumb_llm_trader.decision import Action, DecisionParseError, DecisionParser
+
+
+def test_parse_json_in_code_block():
+    parser = DecisionParser()
+    response = """
+    Trading analysis...
+    ```json
+    {
+        "action": "buy",
+        "confidence": 0.82,
+        "amount": 0.0125,
+        "target_price": 91500000,
+        "reasoning": "Bullish momentum with strong support",
+        "stop_loss": 90000000,
+        "take_profit": 94000000
+    }
+    ```
+    """
+    decision = parser.parse(response)
+    assert decision.action is Action.BUY
+    assert decision.confidence == pytest.approx(0.82)
+    assert decision.amount == pytest.approx(0.0125)
+    assert decision.target_price == pytest.approx(91500000)
+    assert decision.stop_loss == pytest.approx(90000000)
+    assert decision.take_profit == pytest.approx(94000000)
+
+
+def test_parse_invalid_json():
+    parser = DecisionParser()
+    with pytest.raises(DecisionParseError):
+        parser.parse("no json here")
+
+
+def test_reject_invalid_action():
+    parser = DecisionParser()
+    text = '{"action": "long", "confidence": 0.9, "amount": 1}'
+    with pytest.raises(DecisionParseError):
+        parser.parse(text)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,100 @@
+"""Integration tests for the trading engine orchestration."""
+
+from __future__ import annotations
+
+from bithumb_llm_trader.config import APIConfig, RiskConfig, StrategyConfig
+from bithumb_llm_trader.decision import Action
+from bithumb_llm_trader.engine import TradingEngine
+from bithumb_llm_trader.llm import LLMClient, LLMDecisionMaker
+
+
+class DummyAPI:
+    def __init__(self) -> None:
+        self.orders = []
+
+    def get_ticker(self, order_currency: str, payment_currency: str):
+        return {"data": {"closing_price": "1000000"}}
+
+    def get_orderbook(self, order_currency: str, payment_currency: str):
+        return {
+            "data": {
+                "bids": [{"price": "999000", "quantity": "1"}],
+                "asks": [{"price": "1001000", "quantity": "1"}],
+            }
+        }
+
+    def get_balance(self, order_currency: str, payment_currency: str):
+        return {
+            "data": {
+                "available_btc": "0.8",
+                "available_krw": "5000000",
+            }
+        }
+
+    def place_order(
+        self,
+        order_type: str,
+        order_currency: str,
+        payment_currency: str,
+        units: str,
+        price: str,
+    ):
+        self.orders.append({
+            "type": order_type,
+            "order_currency": order_currency,
+            "payment_currency": payment_currency,
+            "units": units,
+            "price": price,
+        })
+        return {"status": "0000", "data": {"order_id": "123"}}
+
+
+class DummyLLM(LLMClient):
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.prompts = []
+
+    def generate(self, prompt: str, **kwargs) -> str:  # type: ignore[override]
+        self.prompts.append(prompt)
+        return self.response
+
+
+def test_engine_dry_run_skips_order():
+    api = DummyAPI()
+    config = StrategyConfig(
+        api=APIConfig(api_key="key", api_secret="secret"),
+        dry_run=True,
+        risk=RiskConfig(max_trade_value=10_000_000, max_position_size=1.0),
+    )
+    llm_client = DummyLLM('{"action": "BUY", "confidence": 0.9, "amount": 0.5}')
+    decision_maker = LLMDecisionMaker(llm_client)
+    engine = TradingEngine(api, decision_maker, config)
+
+    result = engine.run_once()
+
+    assert result.action is Action.BUY
+    assert api.orders == []  # dry run should not call place_order
+    assert len(engine.history) == 1
+    assert llm_client.prompts  # prompt should be generated
+
+
+def test_engine_places_order_when_live():
+    api = DummyAPI()
+    config = StrategyConfig(
+        api=APIConfig(api_key="key", api_secret="secret"),
+        dry_run=False,
+        risk=RiskConfig(max_trade_value=10_000_000, max_position_size=0.4),
+    )
+    llm_client = DummyLLM('{"action": "SELL", "confidence": 0.9, "amount": 0.5, "target_price": 1000000}')
+    decision_maker = LLMDecisionMaker(llm_client)
+    engine = TradingEngine(api, decision_maker, config)
+
+    result = engine.run_once()
+
+    assert result.action is Action.SELL
+    assert api.orders  # order placed
+    order = api.orders[0]
+    assert order["type"] == "ask"
+    # Amount limited by risk manager to max_position_size 0.4
+    assert float(order["units"]) == 0.4
+    assert result.target_price == 1000000

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -1,0 +1,53 @@
+"""Unit tests for the risk manager."""
+
+from __future__ import annotations
+
+import pytest
+
+from bithumb_llm_trader.config import RiskConfig
+from bithumb_llm_trader.decision import Action, TradeDecision
+from bithumb_llm_trader.risk import RiskManager
+
+
+@pytest.fixture
+def market_state():
+    return {"ticker": {"closing_price": "1000000"}}
+
+
+@pytest.fixture
+def account_state():
+    return {"balance_order_currency": 0.5, "balance_payment_currency": 3000000}
+
+
+def test_buy_adjusted_by_cash_limits(market_state, account_state):
+    manager = RiskManager(RiskConfig(max_trade_value=1_000_000, max_position_size=1))
+    decision = TradeDecision(
+        action=Action.BUY,
+        confidence=0.9,
+        amount=5,
+        target_price=1_000_000,
+        reasoning="Test"
+    )
+    adjusted = manager.apply(decision, market_state, account_state)
+    assert adjusted.action is Action.BUY
+    # Limited by max_trade_value (1M / price 1M -> 1 unit)
+    assert adjusted.amount == pytest.approx(1.0)
+    assert adjusted.stop_loss == pytest.approx(980000.0)
+    assert adjusted.take_profit == pytest.approx(1030000.0)
+
+
+def test_sell_rejected_without_inventory(market_state):
+    manager = RiskManager(RiskConfig())
+    account_state = {"balance_order_currency": 0.0, "balance_payment_currency": 0.0}
+    decision = TradeDecision(action=Action.SELL, confidence=0.8, amount=1.0)
+    adjusted = manager.apply(decision, market_state, account_state)
+    assert adjusted.action is Action.HOLD
+    assert "No inventory" in adjusted.reasoning
+
+
+def test_low_confidence_rejected(market_state, account_state):
+    manager = RiskManager(RiskConfig(min_confidence=0.7))
+    decision = TradeDecision(action=Action.BUY, confidence=0.5, amount=0.1)
+    adjusted = manager.apply(decision, market_state, account_state)
+    assert adjusted.action is Action.HOLD
+    assert "confidence" in adjusted.reasoning


### PR DESCRIPTION
## Summary
- add a modular Python package for an LLM-driven Bithumb trading engine with API client, configuration, decision parsing, risk control, and CLI
- build prompt generation and LLM decision integration with adjustable risk handling and dry-run support
- provide Pytest coverage for API signing, decision parsing, risk management, and engine orchestration along with updated documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd336b98f8833387b577611b7d684e